### PR TITLE
Fixed #29 - problem with appcontext

### DIFF
--- a/oarepo_oai_pmh_harvester/cli.py
+++ b/oarepo_oai_pmh_harvester/cli.py
@@ -63,37 +63,46 @@ def run(provider, synchronizer, break_on_error, start_oai, start_id, oai, overwr
     """
     api = create_api()
     with api.app_context():
-        l = len(oai)
-        if index:
-            current_oai_client.es_index = index
-        if l > 0 and provider and synchronizer and not start_oai and not start_id:
-            assert len(provider) <= 1, "OAI option is only for one provider and synchronizer"
-            assert len(synchronizer) <= 1, "OAI option is only for one provider and synchronizer"
-            provider = provider[0]
-            synchronizer = synchronizer[0]
-            current_oai_client.run_synchronizer_by_ids(
-                list(oai),
-                provider,
-                synchronizer,
-                break_on_error=break_on_error,
-                overwrite=overwrite,
-                bulk=bulk,
-                only_fetch=only_fetch
-            )
+        _run_internal(provider=provider, synchronizer=synchronizer, break_on_error=break_on_error,
+                      start_oai=start_oai, start_id=start_id, oai=oai, overwrite=overwrite,
+                      bulk=bulk, only_fetch=only_fetch, index=index)
+
+
+def _run_internal(provider: tuple = tuple(), synchronizer: tuple = tuple(), break_on_error: bool = True,
+                  start_oai: str = None, start_id: int = 0, oai: tuple = tuple(),
+                  overwrite: bool = False, bulk: bool = True, only_fetch: bool = False,
+                  index: str = None):
+    l = len(oai)
+    if index:
+        current_oai_client.es_index = index
+    if l > 0 and provider and synchronizer and not start_oai and not start_id:
+        assert len(provider) <= 1, "OAI option is only for one provider and synchronizer"
+        assert len(synchronizer) <= 1, "OAI option is only for one provider and synchronizer"
+        provider = provider[0]
+        synchronizer = synchronizer[0]
+        current_oai_client.run_synchronizer_by_ids(
+            list(oai),
+            provider,
+            synchronizer,
+            break_on_error=break_on_error,
+            overwrite=overwrite,
+            bulk=bulk,
+            only_fetch=only_fetch
+        )
+    else:
+        assert l == 0, " If OAI option is used, the provider and synchronizer must be " \
+                       "specified and star_id or start_oai must not be used"
+        if not provider:
+            provider = None
         else:
-            assert l == 0, " If OAI option is used, the provider and synchronizer must be " \
-                           "specified and star_id or start_oai must not be used"
-            if not provider:
-                provider = None
-            else:
-                provider = list(provider)
-            if not synchronizer:
-                synchronizer = None
-            else:
-                synchronizer = list(synchronizer)
-            current_oai_client.run(providers_codes=provider, synchronizers_codes=synchronizer,
-                                   break_on_error=break_on_error, start_oai=start_oai,
-                                   start_id=start_id, only_fetch=only_fetch)
+            provider = list(provider)
+        if not synchronizer:
+            synchronizer = None
+        else:
+            synchronizer = list(synchronizer)
+        current_oai_client.run(providers_codes=provider, synchronizers_codes=synchronizer,
+                               break_on_error=break_on_error, start_oai=start_oai,
+                               start_id=start_id, only_fetch=only_fetch)
 
 
 @oai.command("fix")

--- a/oarepo_oai_pmh_harvester/decorators.py
+++ b/oarepo_oai_pmh_harvester/decorators.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Any, Callable
 
 from oarepo_oai_pmh_harvester.proxies import current_oai_client
 from oarepo_oai_pmh_harvester.transformer import OAITransformer
@@ -34,7 +34,7 @@ def endpoint_handler(provider: str = None, parser: str = None,
 
 
 def pre_processor(provider: str = None, parser: str = None,
-                  provider_parser_list: List[Dict] = None) -> None:
+                  provider_parser_list: List[Dict] = None) -> Callable:
     """
     Decorator that register function for pre processing. You can insert provider and parser or
     list of dict that contain more providers. Dict must have two keys provider and parser.
@@ -61,7 +61,7 @@ def pre_processor(provider: str = None, parser: str = None,
 
 
 def post_processor(provider: str = None, parser: str = None,
-                   provider_parser_list: List[Dict] = None) -> None:
+                   provider_parser_list: List[Dict] = None) -> Callable:
     """
     Decorator that register function for post processing. You can insert provider and parser or
     list of dict that contain more providers. Dict must have two keys provider and parser.

--- a/oarepo_oai_pmh_harvester/version.py
+++ b/oarepo_oai_pmh_harvester/version.py
@@ -13,4 +13,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '2.0.0a23'
+__version__ = '2.0.0a24'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,34 +1,26 @@
 from unittest import mock
 
-from oarepo_oai_pmh_harvester.cli import run
+from oarepo_oai_pmh_harvester.cli import run, _run_internal
 from tests.helpers import mock_harvest
 
 
 def test_run(load_entry_points, app, db):
     patch = mock.patch('sickle.app.Sickle.harvest', mock_harvest)
     patch.start()
-    runner = app.test_cli_runner()
-    result = runner.invoke(run, ["-p", "uk"])
-    assert result.exit_code == 0
+    _run_internal(provider=("uk",))
     patch.stop()
 
 
 def test_run_2(load_entry_points, app, db):
     patch = mock.patch('sickle.app.Sickle.harvest', mock_harvest)
     patch.start()
-    runner = app.test_cli_runner()
-    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "-a", "oai:test.example.com:1585322"])
-    assert result.exit_code == 0
-    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "-a", "oai:test.example.com:1585322",
-                                 "--overwrite"])
-    assert result.exit_code == 0
+    _run_internal(provider=("uk",), synchronizer=("xoai",), oai=("oai:test.example.com:1585322",))
+    _run_internal(provider=("uk",), synchronizer=("xoai",), oai=("oai:test.example.com:1585322",))
     patch.stop()
 
 
 def test_run_only_fetch(load_entry_points, app, db, index):
     patch = mock.patch('sickle.app.Sickle.harvest', mock_harvest)
     patch.start()
-    runner = app.test_cli_runner()
-    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "--only-fetch", "-x", "test_index"])
-    assert result.exit_code == 0
+    _run_internal(provider=("uk",), synchronizer=("xoai",), only_fetch=True, index="test_index")
     patch.stop()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,10 @@ def test_run_2(load_entry_points, app, db):
     patch = mock.patch('sickle.app.Sickle.harvest', mock_harvest)
     patch.start()
     runner = app.test_cli_runner()
-    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "-a", "oai:test.example.com:1996652"])
+    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "-a", "oai:test.example.com:1585322"])
+    assert result.exit_code == 0
+    result = runner.invoke(run, ["-p", "uk", "-s", "xoai", "-a", "oai:test.example.com:1585322",
+                                 "--overwrite"])
     assert result.exit_code == 0
     patch.stop()
 


### PR DESCRIPTION
Problem was with the app context creation. Former application used only @with_appcontext decorator, but invenio dived contexts into UI and REST. For rest app, creation_api factory must be used (see cli.py module).