### PR TITLE
Administration access through role

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-oai-pmh-harvester
-version = 5.0.6
+version = 5.0.7
 description = OAIPMH harvester
 authors = ["Alzbeta Pokorna <alzbeta.pokorna@cesnet.cz>", "Miroslav Simek <miroslav.simek@cesnet.cz>"]
 readme = README.md


### PR DESCRIPTION
This fix allows to have user assigned to invenio role (for example, 'repository-managers') that is given administration access. This has not worked before as access through role was not checked.